### PR TITLE
Fixed card text color

### DIFF
--- a/components/ui/experience-item-card.jsx
+++ b/components/ui/experience-item-card.jsx
@@ -1,8 +1,8 @@
-const ExperienceCard = ({ title, subtitle, link, cardColor, textColor }) => {
+const ExperienceCard = ({ title, subtitle, link, cardColor, textColor, svgColor }) => {
     const cardClass = `card w-full ${cardColor} shadow-xl`;
-    const titleTextClass = `text-sm font-semibold text-${textColor}`;
-    const svgClass = `w-6 h-6 ${cardColor} stroke-${textColor}`;
-    const subtitleClass = `text-xs text-${textColor}`;
+    const titleTextClass = `text-sm font-semibold ${textColor}`;
+    const svgClass = `w-6 h-6 ${cardColor} ${svgColor}`;
+    const subtitleClass = `text-xs ${textColor}`;
 
     return (
         <a href={link} className={cardClass} target="_blank" rel="noopener noreferrer">

--- a/components/ui/items-divider.jsx
+++ b/components/ui/items-divider.jsx
@@ -15,7 +15,8 @@ const ItemsDivider = () => {
                             subtitle={item.Subtitle}
                             link={item.Link}
                             cardColor="bg-warning"
-                            textColor="base-200"
+                            textColor="text-base-200"
+                            svgColor="stroke-base-200"
                         />
                     ))}
                 </div>
@@ -29,7 +30,8 @@ const ItemsDivider = () => {
                             subtitle={item.Subtitle}
                             link={item.Link}
                             cardColor="bg-accent"
-                            textColor="base-200"
+                            textColor="text-base-200"
+                            svgColor="stroke-base-200"
                         />
                     ))}
                 </div>
@@ -43,7 +45,8 @@ const ItemsDivider = () => {
                             subtitle={item.Subtitle}
                             link={item.Link}
                             cardColor="bg-info"
-                            textColor="base-200"
+                            textColor="text-base-200"
+                            svgColor="stroke-base-200"
                         />
                     ))}
                 </div>
@@ -57,7 +60,8 @@ const ItemsDivider = () => {
                             subtitle={item.Subtitle}
                             link={item.Link}
                             cardColor="bg-primary"
-                            textColor="base-200"
+                            textColor="text-base-200"
+                            svgColor="stroke-base-200"
                         />
                     ))}
                 </div>


### PR DESCRIPTION
The card text color was appearing the wrong color in some instances. This fix separates out the text color with the svg color and requires the items-divider to pass the full text or svg color class to the experience-items-card component 